### PR TITLE
fix README encoding in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name="ace_step",
     description="ACE Step: A Step Towards Music Generation Foundation Model",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     version="0.1.0",
     packages=["acestep"],


### PR DESCRIPTION
otherwise this happens:

```
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 35, in <module>
        File "C:\Users\rob\AppData\Local\Temp\pip-req-build-fy814bnm\setup.py", line 6, in <module>
          long_description=open("README.md").read(),
        File "C:\Users\rob\Desktop\tts-generation-webui-main\installer_files\env\lib\encodings\cp1252.py", line 23, in decode
          return codecs.charmap_decode(input,self.errors,decoding_table)[0]
      UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 1272: character maps to <undefined>
```